### PR TITLE
Changes related to issue#4 i.e Scroll graph to most recent data via a configurable property

### DIFF
--- a/LMGraphView/LMLineGraphView.h
+++ b/LMGraphView/LMLineGraphView.h
@@ -33,6 +33,8 @@
 
 @property (nonatomic, weak) id<LMLineGraphViewDelegate> delegate;
 
+@property (nonatomic, assign, getter=shouldScrollToRecentData) BOOL scrollToRecentData;
+
 - (void)animateWithDuration:(NSTimeInterval)duration;
 
 - (UIImage *)graphImage;

--- a/LMGraphView/LMLineGraphView.m
+++ b/LMGraphView/LMLineGraphView.m
@@ -233,6 +233,14 @@
         
         // Draw plots
         [self drawPlots];
+        
+        if(self.shouldScrollToRecentData) {
+            ///Scroll to most recent data
+            CGSize contentScrollViewSize = self.contentScrollView.contentSize;
+            if(contentScrollViewSize.width > W(self.contentScrollView)) {
+                [self.contentScrollView scrollRectToVisible:CGRectMake(contentScrollViewSize.width - W(self.contentScrollView), self.contentScrollView.contentOffset.y, contentScrollViewSize.width, contentScrollViewSize.height) animated:YES];
+            }
+        }
     }
     else
     {


### PR DESCRIPTION
An option to scroll the graph to most recent data is provided which is manageable via a public property named scrollToRecentData in LMLineGraphView class and is default to NO which means old behaviour remains intact unless the scrollToRecentData property is set to YES